### PR TITLE
Added step to composer update dev-ops/analyze

### DIFF
--- a/environments/shopware.md
+++ b/environments/shopware.md
@@ -63,11 +63,15 @@ The below example demonstrates the from-scratch setup of the Shopware 6 applicat
 
         echo $'const:\n  APP_URL: "https://app.exampleproject.test"\n' > .psh.yaml.override
 
-9.  Install the Shopware application complete with sample data:
+9.  Update any packages in `./dev-ops/analyze` that may be out of date:
+
+        composer update --working-dir=./dev-ops/analyze
+
+10.  Install the Shopware application complete with sample data:
 
         ./psh.phar install
 
-10. Launch the application in your browser:
+11. Launch the application in your browser:
 
     - [https://app.exampleproject.test/](https://app.exampleproject.test/)
     - [https://app.exampleproject.test/admin/](https://app.exampleproject.test/admin/)


### PR DESCRIPTION
While running a vanilla Shopware install from scratch I noticed that the `psh.phar install` command would fail because of outdated packages in `./dev-ops/analyze` and error out completely. The only fix for this was to update the composer packages in that directory so adding a step in to the docs to help other devs. I am not sure if this is best practice, maybe other more experienced Shopware devs can comment. 