### PR TITLE
Update to Python3 for OTP secret generation

### DIFF
--- a/environments/magento2.md
+++ b/environments/magento2.md
@@ -173,7 +173,9 @@ In addition to the below manual process, there is a `Github Template available f
 
          ## Configure 2FA provider
          OTPAUTH_QRI=
-         TFA_SECRET=$(python -c "import base64; print base64.b32encode('$(pwgen -A1 128)')" | sed 's/=*$//')
+         # Python 2: TFA_SECRET=$(python -c "import base64; print base64.b32encode('$(pwgen -A1 128)')" | sed 's/=*$//')
+         # Python 3:
+         TFA_SECRET=$(python3 -c "import base64; print(base64.b32encode(bytearray('$(pwgen -A1 128)', 'ascii')).decode('utf-8'))" | sed 's/=*$//')
          OTPAUTH_URL=$(printf "otpauth://totp/%s%%3Alocaladmin%%40example.com?issuer=%s&secret=%s" \
              "${TRAEFIK_SUBDOMAIN}.${TRAEFIK_DOMAIN}" "${TRAEFIK_SUBDOMAIN}.${TRAEFIK_DOMAIN}" "${TFA_SECRET}"
          )


### PR DESCRIPTION
Existing documentation uses "python" command which relies upon Python2; however, Python3 is installed by default. This adds the Python3 variant of the command for OTP secret generation.