### PR TITLE
feat: add sphinx autobuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
+SPHINXAUTOBUILD = sphinx-autobuild
 SOURCEDIR     = .
 BUILDDIR      = _build
 
@@ -11,7 +12,10 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help Makefile watch
+
+watch:
+	@$(SPHINXAUTOBUILD) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(0)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 sphinx>=5.0.0,<6.0.0
+sphinx-autobuild==2024.10.3
 sphinx_rtd_theme>=1.0.0,<2.0
 myst-parser>=0.18.0,<1.0
 sphinx-copybutton>=0.2.11,<1.0


### PR DESCRIPTION
This PR proposes to install the Sphinx Autobuild package to simplify local development of the docs. Some key features it provides are:
- Built-in Web Server
- Hot Reloading on source file change

With this, the proposed local build steps would be
```sh
git clone https://github.com/wardenenv/docs.git warden-docs && cd warden-docs
pip install -r requirements.txt
make watch
```