### PR TITLE
Fix CI Builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Run Sphinx documentation build
-        uses: ammaraskar/sphinx-action@0.4
+        uses: ammaraskar/sphinx-action@8.1.3
         with:
           docs-folder: "./"
       - name: Upload documentation artifact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Sphinx documentation build
         uses: ammaraskar/sphinx-action@8.1.3
         with:
           docs-folder: "./"
       - name: Upload documentation artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: _build/html/
   deploy:
@@ -38,4 +38,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Run Sphinx documentation build
-        uses: ammaraskar/sphinx-action@0.4
+        uses: ammaraskar/sphinx-action@8.1.3
         with:
           docs-folder: "./"
       - name: Upload documentation artifact

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Sphinx documentation build
         uses: ammaraskar/sphinx-action@8.1.3
         with:
           docs-folder: "./"
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: _build/html/

--- a/conf.py
+++ b/conf.py
@@ -37,10 +37,8 @@ release = ''
 exclude_patterns = ['_build']
 
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_show_sourcelink = False
 
-html_static_path = ['_static']
 templates_path = ['_templates']
 html_extra_path = ['_redirects']
 

--- a/index.md
+++ b/index.md
@@ -1,13 +1,6 @@
 Welcome to Warden's documentation!
 ==================================
 
-```{include} ../README.md
----
-start-line: 1
-end-before: <!-- include_open_stop -->
----
-```
-
 Under the hood `docker-compose` is used to control everything which Warden runs (shared services as well as per-project containers) via the Docker Engine.
 
 ## Features

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-sphinx>=5.0.0,<6.0.0
+Sphinx==8.1.3
 sphinx-autobuild==2024.10.3
-sphinx_rtd_theme>=1.0.0,<2.0
-myst-parser>=0.18.0,<1.0
-sphinx-copybutton>=0.2.11,<1.0
-sphinx-markdown-tables>=0.0.15,<1.0
-jinja2>=3.0
+sphinx-copybutton==0.5.2
+sphinx-markdown-tables==0.0.17
+sphinx-rtd-theme==3.0.2
+myst-parser==4.0.0
+Jinja2==3.1.4


### PR DESCRIPTION
Fixes the failing CI builds, that was caused by loose dependencies in the upstream actions. Ref: https://github.com/wardenenv/docs/pull/24#issuecomment-2438955497 

(Happy to split into multiple smaller PR's if preferred).

## Example CI Runs & Resulting build
On PR: https://github.com/SamJUK/warden-docs/actions/runs/11882793013
On Main push: https://github.com/SamJUK/warden-docs/actions/runs/11882799248
Resulting documentation: https://samjuk.github.io/warden-docs/

## Changes
- Pins the python package versions, hopefully should improve reproducibility of builds.
- Update Sphinx to the latest version (8.1.3), and remaining packages to latest compatible versions.
- Removes redundant configuration, that triggers warnings in the build process on the new Sphinx version.
- Bumps Github Actions versions to improve performance & remove deprecation warnings from the build logs.