### PR TITLE
docs: add browser profiling section to Blackfire guide

### DIFF
--- a/configuration/blackfire.md
+++ b/configuration/blackfire.md
@@ -19,4 +19,23 @@ Note: You can obtain the IDs and Tokens used in the above from within your Black
 
 To use the Blackfire CLI Tool, you can run `warden blackfire [arguments]`.
 
-For more information on the CLI tool, please see [Profiling CLI Commands](https://blackfire.io/docs/cookbooks/profiling-cli) in Blackfire's documentation. 
+For more information on the CLI tool, please see [Profiling CLI Commands](https://blackfire.io/docs/cookbooks/profiling-cli) in Blackfire's documentation.
+
+## Browser Profiling
+
+Blackfire provides browser extensions that let you profile any page directly from the toolbar. Install the extension for your browser, log in to your Blackfire account, navigate to the page you want to profile, and click the **Profile** button in the extension.
+
+For a full walkthrough, see [Profiling HTTP Requests with a Browser](https://docs.blackfire.io/profiling-cookbooks/profiling-http-via-browser) in Blackfire's documentation.
+
+### Browser extensions
+
+  * [Firefox extension](https://docs.blackfire.io/integrations/browsers/firefox) — **recommended**, supports all profiling features including **Profile all requests** (POST, Ajax, API calls)
+  * [Chrome extension](https://docs.blackfire.io/integrations/browsers/chrome) — single-page profiling works, but **Profile all requests** is unavailable (see below)
+
+### Chrome limitation
+
+Chrome's Manifest V3 restricts extensions from modifying outgoing request headers, which breaks the **Profile all requests** feature. This means Chrome can only profile the initial page load — it cannot capture follow-up POST requests, Ajax calls, or API requests within a session.
+
+Single-page profiling (clicking **Profile** on a specific URL) still works normally in Chrome.
+
+If your workflow relies on profiling all requests in a session, **use Firefox** where this feature remains fully supported. For more details, see [Announcing changes to the "Profile all requests" feature on Chrome](https://blog.blackfire.io/announcing-changes-to-the-profile-all-requests-feature-on-chrome.html) on the Blackfire blog.

--- a/configuration/blackfire.md
+++ b/configuration/blackfire.md
@@ -34,8 +34,8 @@ For a full walkthrough, see [Profiling HTTP Requests with a Browser](https://doc
 
 ### Chrome limitation
 
-Chrome's Manifest V3 restricts extensions from modifying outgoing request headers, which breaks the **Profile all requests** feature. This means Chrome can only profile the initial page load — it cannot capture follow-up POST requests, Ajax calls, or API requests within a session.
-
-Single-page profiling (clicking **Profile** on a specific URL) still works normally in Chrome.
+:::{warning}
+Chrome's Manifest V3 restricts extensions from modifying outgoing request headers, which breaks the **Profile all requests** feature. Chrome can only profile the initial page load — it cannot capture follow-up POST requests, Ajax calls, or API requests within a session. Single-page profiling still works normally.
 
 If your workflow relies on profiling all requests in a session, **use Firefox** where this feature remains fully supported. For more details, see [Announcing changes to the "Profile all requests" feature on Chrome](https://blog.blackfire.io/announcing-changes-to-the-profile-all-requests-feature-on-chrome.html) on the Blackfire blog.
+:::


### PR DESCRIPTION
## Summary

- Add a **Browser Profiling** section to the [Blackfire configuration](https://docs.warden.dev/configuration/blackfire.html) page
- Document how to use Blackfire browser extensions for HTTP profiling
- Explain that Chrome's Manifest V3 breaks the "Profile all requests" feature — only single-page profiling works
- Recommend Firefox as the browser with full profiling support (POST, Ajax, API calls)
- Link to official Blackfire sources:
  - [Profiling HTTP via Browser](https://docs.blackfire.io/profiling-cookbooks/profiling-http-via-browser)
  - [Chrome Manifest V3 announcement](https://blog.blackfire.io/announcing-changes-to-the-profile-all-requests-feature-on-chrome.html)
