### PR TITLE
fix: convert rST link to Markdown in Magento 2 setup guide

### DIFF
--- a/environments/magento2.md
+++ b/environments/magento2.md
@@ -3,7 +3,7 @@
 The below example demonstrates the from-scratch setup of the Magento 2 application for local development. A similar process can easily be used to configure an environment of any other type. This assumes that Warden has been previously started via `warden svc up` as part of the installation procedure.
 
 :::{note}
-In addition to the below manual process, there is a `Github Template available for Magento 2 <https://github.com/wardenenv/warden-env-magento2>`_ allowing for quick setup of new Magento projects. To use this, click the green "Use this template" button to create your own repository based on the template repository, run the init script and update the README with any project specific information.
+In addition to the below manual process, there is a [Github Template available for Magento 2](https://github.com/wardenenv/warden-env-magento2) allowing for quick setup of new Magento projects. To use this, click the green "Use this template" button to create your own repository based on the template repository, run the init script and update the README with any project specific information.
 :::
 
 1. Create a new directory on your host machine at the location of your choice and then jump into the new directory to get started:


### PR DESCRIPTION
## Summary

- Fix broken link to the [Magento 2 GitHub Template](https://github.com/wardenenv/warden-env-magento2) in the Magento 2 installation guide
- The link used reStructuredText syntax (`` `text <url>`_ ``) which renders as inline code in MyST Markdown instead of a clickable link
- Converted to standard Markdown link syntax (`[text](url)`)
