### PR TITLE
fix: update stale mailhog.warden.test URLs to webmail.warden.test

### DIFF
--- a/environments/magento2.md
+++ b/environments/magento2.md
@@ -234,7 +234,7 @@ In addition to the below manual process, there is a `Github Template available f
      :::
 
      :::{note}
-     Use of 2FA is mandatory on Magento ``2.4.x`` and setup of 2FA should be skipped when installing ``2.3.x`` or earlier. Where 2FA is setup manually via UI upon login rather than using the CLI commands above, the 2FA configuration email may be retrieved from `the Mailhog service <https://mailhog.warden.test/>`_.
+     Use of 2FA is mandatory on Magento ``2.4.x`` and setup of 2FA should be skipped when installing ``2.3.x`` or earlier. Where 2FA is setup manually via UI upon login rather than using the CLI commands above, the 2FA configuration email may be retrieved from [the webmail service](https://webmail.warden.test/).
      :::
 
 11. Launch the application in your browser:

--- a/environments/types.md
+++ b/environments/types.md
@@ -96,7 +96,7 @@ Files are currently mounted using a delegated mount on macOS and natively on Lin
 
 ## Commonalities
 
-In addition to the above, each environment type (with the exception of the `local` type) come with PHP setup to use `mhsendmail` to ensure outbound email does not inadvertently leave your network and to support simpler testing of email functionality. Mailhog may be accessed by navigating to [https://mailhog.warden.test/](https://mailhog.warden.test/) in a browser.
+In addition to the above, each environment type (with the exception of the `local` type) come with PHP setup to use `mhsendmail` to ensure outbound email does not inadvertently leave your network and to support simpler testing of email functionality. The webmail interface may be accessed by navigating to [https://webmail.warden.test/](https://webmail.warden.test/) in a browser.
 
 Where PHP is specified in the above list, there should be two `fpm` containers, `php-fpm` and `php-debug` in order to provide Xdebug support. Use of Xdebug is enabled by setting the `XDEBUG_SESSION` cookie in your browser to direct the request to the `php-debug` container. Shell sessions opened in the debug container via `warden debug` will also connect PHP process for commands on the CLI to Xdebug.
 

--- a/services.md
+++ b/services.md
@@ -5,7 +5,7 @@ After running `warden svc up` for the first time following installation, the fol
 * [https://traefik.warden.test/](https://traefik.warden.test/)
 * [https://portainer.warden.test/](https://portainer.warden.test/)
 * [https://dnsmasq.warden.test/](https://dnsmasq.warden.test/)
-* [https://mailhog.warden.test/](https://mailhog.warden.test/)
+* [https://webmail.warden.test/](https://webmail.warden.test/)
 
 ## Customizable Settings
 


### PR DESCRIPTION
## Summary

Since Warden moved from Mailhog to Mailpit in v0.15.0, the webmail URL changed to `https://webmail.warden.test/`. Three docs pages still referenced the old `mailhog.warden.test` URL:

- `services.md` — global services URL list
- `environments/types.md` — commonalities section
- `environments/magento2.md` — 2FA setup note (also fixed broken rST link syntax)
