### PR TITLE
docs: add phpMyAdmin to global services documentation

### DIFF
--- a/services.md
+++ b/services.md
@@ -6,6 +6,7 @@ After running `warden svc up` for the first time following installation, the fol
 * [https://portainer.warden.test/](https://portainer.warden.test/)
 * [https://dnsmasq.warden.test/](https://dnsmasq.warden.test/)
 * [https://mailhog.warden.test/](https://mailhog.warden.test/)
+* [https://phpmyadmin.warden.test/](https://phpmyadmin.warden.test/)
 
 ## Customizable Settings
 
@@ -16,6 +17,7 @@ The following options are available (with default values indicated):
 * `TRAEFIK_LISTEN=127.0.0.1` may be set to `0.0.0.0` for example to have Traefik accept connections from other devices on the local network.
 * `WARDEN_RESTART_POLICY=always` may be set to `no` to prevent Docker from restarting these service containers or any other valid [restart policy](https://docs.docker.com/config/containers/start-containers-automatically/#use-a-restart-policy) value.
 * `WARDEN_SERVICE_DOMAIN=warden.test` may be set to a domain of your choosing if so desired. Please note that this will not currently change network settings or alter `dnsmasq` configuration. Any TLD other than `test` will require DNS resolution be manually configured.
+* `WARDEN_PHPMYADMIN_ENABLE=1` may be set to `0` to disable the phpMyAdmin global service.
 
 :::{warning}
 Setting ``TRAEFIK_LISTEN=0.0.0.0`` can be quite useful in some cases, but be aware that causing Traefik to listen for requests publicly poses a security risk when on public WiFi or networks otherwise outside of your control.


### PR DESCRIPTION
## Summary

- Add `https://phpmyadmin.warden.test/` to the global services URL list
- Document `WARDEN_PHPMYADMIN_ENABLE=1` setting (can be set to `0` to disable)

phpMyAdmin was added in v0.15.0 ([#801](https://github.com/wardenenv/warden/pull/801)) but was not reflected in the services documentation.
