### PR TITLE
docs: reorganize usage page by service type

### DIFF
--- a/usage.md
+++ b/usage.md
@@ -1,18 +1,38 @@
 # Warden Usage
 
-## Common Commands
+## Environment Management
 
-Launch a shell session within the project environment's `php-fpm` container:
+Starting a stopped environment:
 
-    warden shell
+    warden env start
 
 Stopping a running environment:
 
     warden env stop
 
-Starting a stopped environment:
+Display the resolved environment configuration in `docker-compose` format:
 
-    warden env start
+    warden env config
+
+Tail environment nginx and php logs:
+
+    warden env logs --tail 0 -f nginx php-fpm php-debug
+
+Remove volumes completely:
+
+    warden env down -v
+
+## Shell Access
+
+Launch a shell session within the project environment's `php-fpm` container:
+
+    warden shell
+
+Launch a debug-enabled shell (Xdebug) session:
+
+    warden debug
+
+## Database
 
 Import a database (if you don't have `pv` installed, use `cat` instead):
 
@@ -22,17 +42,7 @@ Monitor database processlist:
 
     watch -n 3 "warden db connect -A -e 'show processlist'"
 
-Tail environment nginx and php logs:
-
-    warden env logs --tail 0 -f nginx php-fpm php-debug
-
-Tail the varnish activity log:
-
-    warden env exec -T varnish varnishlog
-
-Flush varnish:
-
-     warden env exec -T varnish varnishadm 'ban req.url ~ .' 
+## Redis / Valkey
 
 Connect to redis/valkey:
 
@@ -44,15 +54,23 @@ Flush redis/valkey completely:
     warden redis flushall
     warden valkey flushall
 
-Run redis continuous stat mode
+Run redis continuous stat mode:
 
     warden redis --stat
 
-Remove volumes completely:
+## Varnish
 
-    warden env down -v
+Tail the varnish activity log:
 
-Warden troubleshooting and debug information
+    warden env exec -T varnish varnishlog
+
+Flush varnish:
+
+     warden env exec -T varnish varnishadm 'ban req.url ~ .'
+
+## Troubleshooting
+
+Warden troubleshooting and debug information:
 
     warden doctor
 


### PR DESCRIPTION
## Summary

- Reorganize the flat command list on the [Usage](https://docs.warden.dev/usage.html) page into logical sections:
  - **Environment Management** — start, stop, config, logs, down
  - **Shell Access** — shell, debug
  - **Database** — import, processlist
  - **Redis / Valkey** — connect, flushall, stat
  - **Varnish** — activity log, flush
  - **Troubleshooting** — doctor
- Add undocumented `warden env config` command (displays resolved docker-compose configuration)
- All existing commands preserved — no content removed, only regrouped
