### PR TITLE
docs: add SSH tunnel to global services list

### DIFF
--- a/services.md
+++ b/services.md
@@ -6,6 +6,7 @@ After running `warden svc up` for the first time following installation, the fol
 * [https://portainer.warden.test/](https://portainer.warden.test/)
 * [https://dnsmasq.warden.test/](https://dnsmasq.warden.test/)
 * [https://mailhog.warden.test/](https://mailhog.warden.test/)
+* `tunnel.warden.test` (SSH tunnel on port `2222` for connecting database clients — see [Database Connections](https://docs.warden.dev/configuration/database.html))
 
 ## Customizable Settings
 


### PR DESCRIPTION
## Summary

- Add `tunnel.warden.test` (port `2222`) to the global services URL list on the [Services](https://docs.warden.dev/services.html) page
- Link to the existing [Database Connections](https://docs.warden.dev/configuration/database.html) page for configuration details

The SSH tunnel is a core global service (auto-configured during `warden install`) used for connecting database clients like TablePlus, Sequel Pro, PhpStorm, etc. — but it was missing from the services overview.
